### PR TITLE
Already fixing your crappy code over here. : )

### DIFF
--- a/lib/eager_record/eager_preloading.rb
+++ b/lib/eager_record/eager_preloading.rb
@@ -41,15 +41,17 @@ module EagerRecord
       def load_target_with_eager_preloading
         return nil unless defined?(@loaded)
 
-        if !loaded? and (!@owner.new_record? || foreign_key_present)
-          if originating_collection = @owner.instance_variable_get(:@originating_collection)
-            association_name = @reflection.name
-            @owner.class.__send__(:preload_associations, originating_collection, association_name)
-            new_association = @owner.__send__(:association_instance_get, association_name)
-            if new_association && __id__ != new_association.__id__ && new_association.loaded?
-              @target = new_association.target
-              @loaded = true
-              return
+        if @owner.read_attribute(@reflection.primary_key_name)
+          if !loaded? and (!@owner.new_record? || foreign_key_present)
+            if originating_collection = @owner.instance_variable_get(:@originating_collection)
+              association_name = @reflection.name
+              @owner.class.__send__(:preload_associations, originating_collection, association_name)
+              new_association = @owner.__send__(:association_instance_get, association_name)
+              if new_association && __id__ != new_association.__id__ && new_association.loaded?
+                @target = new_association.target
+                @loaded = true
+                return
+              end
             end
           end
         end

--- a/spec/environment.rb
+++ b/spec/environment.rb
@@ -11,6 +11,7 @@ ActiveRecord::Base.establish_connection(
   :database => File.join(File.dirname(__FILE__), 'test.db')
 )
 
+require 'logger'
 ActiveRecord::Base.logger = Logger.new(File.join(File.dirname(__FILE__), 'test.log'))
 
 require File.join(File.dirname(__FILE__), '..', 'lib', 'eager_record')

--- a/spec/examples/preload_find_spec.rb
+++ b/spec/examples/preload_find_spec.rb
@@ -2,22 +2,41 @@ require File.join(File.dirname(__FILE__), 'spec_helper')
 
 describe 'collection find preloading' do
   before :each do
+    @blog = Blog.create!
     2.times do
-      post = Post.create!
+      post = Post.create!(:blog => @blog)
       post.comments.create!(:approved => true)
-      post.comments.create!(:approved => false)
     end
-    @posts = Post.all
+    @posts = @blog.posts
     @comments = Comment.all
   end
 
   it 'should preload collection #find results for has_many' do
-    @posts[0].comments.approved.should == [@comments[0]]
+    @posts[0].comments.should == [@comments[0]]
     fail_on_select
-    @posts[1].comments.approved.should == [@comments[2]]
+    @posts[1].comments.should == [@comments[1]]
   end
 
   it 'should use normal find if record did not originate in a collection' do
     Post.first.comments.approved.should == [@comments[0]]
+  end
+end
+
+describe 'collection find preloading' do
+  before :each do
+    @post = Post.create!
+    @replies = []
+    10.times do
+      c = @post.comments.create!(:approved => true)
+      @replies << @post.comments.create!(:approved => true, :reply_to => c)
+    end
+  end
+
+  it 'should not perform selects for items in association without a foreign key' do
+    p = @post.reload
+    comments = p.comments
+    comments.inspect
+    fail_on_select
+    comments.each { |c| c.reply_to.inspect unless c.reply_to_id }
   end
 end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -7,6 +7,7 @@ ActiveRecord::Schema.define do
   create_table :comments, :force => true do |t|
     t.references :post
     t.references :user
+    t.integer :reply_to_id
     t.boolean :approved, :null => false, :default => false
   end
   create_table :users, :force => true do |t|

--- a/spec/support/models/comment.rb
+++ b/spec/support/models/comment.rb
@@ -1,6 +1,7 @@
 class Comment < ActiveRecord::Base
   belongs_to :post
   belongs_to :user
+  belongs_to :reply_to, :class_name => 'Comment'
 
   named_scope :approved, :conditions => { :approved => true }
 end

--- a/spec/support/models/post.rb
+++ b/spec/support/models/post.rb
@@ -1,4 +1,5 @@
 class Post < ActiveRecord::Base
+  belongs_to :blog
   has_many :comments
   has_and_belongs_to_many :users
   has_many :assets


### PR DESCRIPTION
First day you're out and I'm already fixing bugs. There's a problem with eager_record where if you have an association like this:

Article => Comment => Reply (comment)

and some of the comments have a nil reply_to_id while some others have a non-nil value, you'll get a million database queries as you loop over the reply_to association. That's because eager record tries to do a preload_association any time it sees an association that's not loaded, and AR counts nil as not loaded. My fix is really just a one-liner to make sure the foreign key has a value before it tries to preload.
